### PR TITLE
Update version to 0.57.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "opentelemetry-instrumentation-sagemaker" %}
-{% set version = "0.49.6" %}
+{% set version = "0.57.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,24 +7,24 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_')}}-{{ version }}.tar.gz
-  sha256: 4ac8ee0bcd308ef30f2d307050e66d98a6182fd4ffb2708ef439749e0b31b02c
+  sha256: 69dad6b708e23baa6ad4b6b9c31bd7f5da86832b46895e5a6fac3a2ad0c9075d
 
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  skip: true  # [py<39]
+  skip: true  # [py<310]
 
 requirements:
   host:
     - python
-    - poetry-core
+    - hatchling
     - pip
   run:
     - python
     - opentelemetry-api >=1.38.0,<2.0.0
     - opentelemetry-instrumentation >=0.59b0
     - opentelemetry-semantic-conventions >=0.59b0
-    - opentelemetry-semantic-conventions-ai >=0.4.13,<0.5
+    - opentelemetry-semantic-conventions-ai <0.6.0,>=0.5
   run_constrained:
     - boto3 >=1.34.120,<2.0.0
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - opentelemetry-api >=1.38.0,<2.0.0
     - opentelemetry-instrumentation >=0.59b0
     - opentelemetry-semantic-conventions >=0.59b0
-    - opentelemetry-semantic-conventions-ai <0.6.0,>=0.5
+    - opentelemetry-semantic-conventions-ai >=0.5.1,<0.6.0
   run_constrained:
     - boto3 >=1.34.120,<2.0.0
 


### PR DESCRIPTION
opentelemetry-instrumentation-sagemaker 0.57.0

**Destination channel:**  defaults

### Links

- [PKG-13428](https://anaconda.atlassian.net/browse/PKG-13428) 
- [Upstream repository](https://github.com/traceloop/openllmetry/blob/v0.57.0/packages/opentelemetry-instrumentation-sagemaker/tests/test_invocation.py)

### Explanation of changes:
- New version number


[PKG-13428]: https://anaconda.atlassian.net/browse/PKG-13428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ